### PR TITLE
Retrieve hitcontent by groupid using the api

### DIFF
--- a/src/main/java/com/tracker/endpoints/HitContentEndpoint.java
+++ b/src/main/java/com/tracker/endpoints/HitContentEndpoint.java
@@ -1,0 +1,25 @@
+package com.tracker.endpoints;
+
+import static com.tracker.ofy.OfyService.ofy;
+
+import java.util.logging.Logger;
+import javax.inject.Named;
+
+import com.google.api.server.spi.config.Api;
+import com.google.api.server.spi.config.ApiMethod;
+import com.google.api.server.spi.config.ApiMethod.HttpMethod;
+import com.tracker.entity.HITcontent;
+
+@Api(name = "mturk", description = "The API for mturk-tracker", version = "v1")
+public class HitContentEndpoint {
+
+	@SuppressWarnings("unused")
+	private static final Logger logger = Logger
+			.getLogger(HitContentEndpoint.class.getName());
+
+	@ApiMethod(name = "hitcontent.getByGroupId", path = "hitcontent/getByGroupId", httpMethod = HttpMethod.GET)
+	public HITcontent getByGroupId(@Named("groupId") String groupId) {
+		return ofy().load().type(HITcontent.class).id(groupId).now();
+	}
+
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -129,7 +129,8 @@
 	        com.tracker.endpoints.HitGroupEndpoint,
 	        com.tracker.endpoints.HitInstanceEndpoint,
 	        com.tracker.endpoints.MarketStatisticsEndpoint,
-	        com.tracker.endpoints.RequesterEndpoint
+	        com.tracker.endpoints.RequesterEndpoint,
+	        com.tracker.endpoints.HitContentEndpoint
 	      </param-value>
 	    </init-param>
 	</servlet>


### PR DESCRIPTION
Adds an API function to retrieve the HITcontent for a certain HIT group id.

Demo at https://apis-explorer.appspot.com/apis-explorer/?base=https://mturkfabc.appspot.com/_ah/api#p/mturk/v1/mturk.hitcontent.getByGroupId

Try any of the following GroupIDs:
301IMZCY2CG8RK75VNWZ188ZIRESDO (has content)
301IMZCY2CVZ337VHVL4RLMINMXDSB (has content)
301IMZCY2CSANIBTHVG1L1ODDRIDS0 (empty content)